### PR TITLE
Feat/webpack hot reload

### DIFF
--- a/client/components/FriendItemList.js
+++ b/client/components/FriendItemList.js
@@ -6,7 +6,7 @@ export function FriendItemList({ friends }) {
     <h1>Your Friends!</h1>
       {
         friends.map(function (friend) {
-          return <FriendItem {...friend} />;
+          return <FriendItem key={friend.id} {...friend} />;
         })
       }
     </div>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A safe driving app for friends",
   "main": "index.js",
   "scripts": {
+    "dev-client": "webpack-dev-server --content-base dist/ --inline",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "expose-loader": "^0.7.1",
     "grunt": "^0.4.5",
     "grunt-jscs": "^2.8.0",
+    "react-hot-loader": "^1.3.0",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,9 @@
+var webpack = require('webpack');
+
 module.exports = {
   entry: [
+    'webpack-dev-server/client?http://localhost:3000',
+    'webpack/hot/only-dev-server',
     './client/app.js',
   ],
   output: {
@@ -8,9 +12,16 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader', },
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loaders: ['react-hot', 'babel-loader'],
+      },
       { test: require.resolve('react'), loader: 'expose?React', },
       { test: /\.css$/, loader: 'style-loader!css-loader' },
     ],
   },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+  ],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,24 +2,28 @@ var webpack = require('webpack');
 
 module.exports = {
   entry: [
-    'webpack-dev-server/client?http://localhost:3000',
+    'webpack-dev-server/client?http://localhost:8080',
     'webpack/hot/only-dev-server',
     './client/app.js',
   ],
   output: {
     path: __dirname + '/dist',
     filename: 'app-bundle.js',
+    publicPath: '/',
   },
   module: {
     loaders: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
+        exclude: /node_modules|server|test/,
         loaders: ['react-hot', 'babel-loader'],
       },
       { test: require.resolve('react'), loader: 'expose?React', },
       { test: /\.css$/, loader: 'style-loader!css-loader' },
     ],
+  },
+  devServer: {
+    hot: true,
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
Implemented hot-reloading for front end development.

@kosticus @gredfearn @philch4n @JosephPena 
To start a client when doing front-end development:
```sh
npm run dev-client
```

Then navigate to
```sh
localhost:8080
```

This page will automatically reload on any changes to files bundled by webpack! yay