### PR TITLE
(feat) added deleteDBso tests have a clean db to start

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express-session": "^1.13.0",
     "immutable": "^3.7.6",
     "knex": "^0.10.0",
+    "knex-cleaner": "^1.1.1",
     "morgan": "^1.7.0",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
@@ -30,6 +31,7 @@
     "reactify": "^1.1.1",
     "redux": "^3.3.1",
     "socket.io": "^1.4.5",
+    "sqlite3": "^3.1.1",
     "supertest": "^1.2.0",
     "supertest-as-promised": "^3.0.0"
   },

--- a/server/apis/user-api.js
+++ b/server/apis/user-api.js
@@ -3,7 +3,6 @@ var UserAPI = require('express').Router();
 
 var Ride = require(__models + '/ride');
 var User = require(__models + '/user');
-console.log('WELCOME TO USER-API!');
 module.exports = UserAPI;
 
 //Get all users
@@ -36,7 +35,5 @@ UserAPI.put('/:id', function (req, res) {
 });
 
 UserAPI.post('/*', function (req, res) {
-  console.log('request:', req);
-  console.log(req.url);
   res.send(200);
 });

--- a/test/server/test_apis/user-api_test.js
+++ b/test/server/test_apis/user-api_test.js
@@ -1,16 +1,20 @@
 require('../../test-helper');
-
+var db = require('../../../lib/db');
 var request = require('supertest');
 var routes = require(__server + '/index.js');
+const dbCleaner = require('knex-cleaner');
 
 describe('Test tester', function () {
+
+  beforeEach(function () {
+    return dbCleaner.clean(db, { mode: 'truncate' });
+  });
 
   var app = TestHelper.createApp();
   app.use('/', routes);
   app.testReady();
 
   it_('serves an example endpoint', function * () {
-
     //
     // Notice how we're in a generator function (indicated by the the *)
     // See test/test-helper.js for details of why this works.
@@ -29,8 +33,6 @@ describe('User API', function () {
   var app = TestHelper.createApp();
   app.use('/', routes);
   app.testReady();
-
-  console.log('routes');
 
   it_('Should insert user', function * () {
     var attrs = {
@@ -62,7 +64,7 @@ describe('User API', function () {
   });
 
   it_('Should get users', function * () {
-    yield request(app)
+    return request(app)
       .get('/user')
       .expect(200)
       .expect(function (response) {


### PR DESCRIPTION
imported knex-cleaner in order to wipe db before the tests start in order to have a clean database to test off of. Added sqlite3 to node modules because knex was complaining about it. I'm not using anywhere, but without it, knex seems to be fussy. 