### PR TITLE
(fix) fix babel compiler errors on generators

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A safe driving app for friends",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive --require test/test-helper.js",
+    "test-server": "./node_modules/.bin/mocha test/server --recursive --require test/test-helper.js",
     "test-client": "./node_modules/.bin/mocha test/client --compilers js:babel-core/register --colors --recursive --require test/test-helper.js",
     "dev-client": "webpack-dev-server --content-base dist/ --inline"
   },


### PR DESCRIPTION
Errors when running npm test.

* npm test would run ES6 syntaxed tests and fail to build but when we configured babel to transpile it, generator functions would not work.