### PR TITLE
Bug/prune rider duplications

### DIFF
--- a/client/actionCreators/ride.js
+++ b/client/actionCreators/ride.js
@@ -32,7 +32,7 @@ export function fetchRide(userId, location) {
   remove it from the rides table.
 */
 export function cancelRide({ user_id, ride_id }) {
-  console.log('canceling ride with object:', user_id, ride_id);
+  // console.log('canceling ride with object:', user_id, ride_id);
   return (dispatch) => {
     dispatch(cancelRideSent());
 

--- a/client/app.js
+++ b/client/app.js
@@ -60,8 +60,8 @@ function geoWatch() {
     };
 
     //!!! Removed for testing of socket new_location events!
-    if (false && user.location && !haveMoved(user.location, nextLocation, 2e-7)) {
-      return;
+    if (false && user.location && !haveMoved(user.location, nextLocation, 2e-8)) {
+      // do nothing
     } else {
       if (!ride.match)
         store.dispatch(userActions.setLocation(nextLocation));
@@ -73,12 +73,12 @@ function geoWatch() {
     let destination = ride.match.location;
     if (ride.isPickedUp) {
       let friendRider = user.friends.find((friend) => friend.user_id === ride.match.user_id);
-      console.log('friendRider:', friendRider);
+
       if (user.isRider) destination = user.profile.address;
       else destination = friendRider.address;
     }
 
-    console.log('routing to:', destination);
+    // console.log('routing to:', destination);
     DirectionsService.route({
       origin: nextLocation,
       destination: destination,

--- a/client/app.js
+++ b/client/app.js
@@ -95,3 +95,9 @@ function haveMoved(curLocation, nextLocation, tol) {
   else
     return false;
 }
+
+/*
+  I (Jonathan) found this for running actions when the tab is closed.
+  We would also need to do this on refresh
+*/
+window.onbeforeunload = function() { /* do things here */ };

--- a/client/app.js
+++ b/client/app.js
@@ -73,10 +73,12 @@ function geoWatch() {
     let destination = ride.match.location;
     if (ride.isPickedUp) {
       let friendRider = user.friends.find((friend) => friend.user_id === ride.match.user_id);
+      console.log('friendRider:', friendRider);
       if (user.isRider) destination = user.profile.address;
       else destination = friendRider.address;
     }
 
+    console.log('routing to:', destination);
     DirectionsService.route({
       origin: nextLocation,
       destination: destination,

--- a/client/components/BottomNavBar/BottomButton.js
+++ b/client/components/BottomNavBar/BottomButton.js
@@ -22,9 +22,16 @@ export function BottomButton({ isWaitingForMatch, isConfirmed, isMatched,
               </h2>
             </div>
           </section>
-        </div> :
+        </div>
+        :
       isMatched ?
-          <Chat match={match}  id={user.user_id} messages={messages}/> :
+        <Chat
+          user_id={user_id}
+          match={match}
+          friends={friends}
+          messages={messages}
+        />
+        :
         <h3>Uh oh. How did this happen?</h3>
     }
     </div>

--- a/client/components/MapView.js
+++ b/client/components/MapView.js
@@ -1,11 +1,17 @@
 import React from 'react';
-import { GoogleMapLoader, GoogleMap, Marker, DirectionsRenderer, InfoWindow } from 'react-google-maps';
+import {
+  GoogleMapLoader,
+  GoogleMap,
+  Marker,
+  DirectionsRenderer,
+  InfoWindow
+} from 'react-google-maps';
 import { connect } from 'react-redux';
 
 // overlayMapTypes
 // MapTypes
 export function MapView({ isRider, isDriver, match, location,
-  friends, riders, directions }) {
+  friends, riders, directions, }) {
 
   let mapOptions = {
     disableDefaultUI: true,

--- a/client/containers/Main.js
+++ b/client/containers/Main.js
@@ -54,7 +54,6 @@ const mapDispatchToProps = function (dispatch) {
     onDirectionsResult(result) {
       // dispatch(rideActions.setDirections(result));
     },
-
   };
 };
 

--- a/client/containers/RiderItemList.js
+++ b/client/containers/RiderItemList.js
@@ -11,8 +11,6 @@ function nullFn(e) { console.log('you clicked me ' + e.target.className); };
 export function List({ ride, user, onRiderClick, }) {
   let _riders = [];
 
-  console.log('driver state ride:', ride);
-
   ride.riders.forEach(function (rider) {
     user.friends.forEach(function (friend) {
       if (friend.user_id === rider.user_id) {

--- a/client/containers/RiderItemList.js
+++ b/client/containers/RiderItemList.js
@@ -11,6 +11,8 @@ function nullFn(e) { console.log('you clicked me ' + e.target.className); };
 export function List({ ride, user, onRiderClick, }) {
   let _riders = [];
 
+  console.log('driver state ride:', ride);
+
   ride.riders.forEach(function (rider) {
     user.friends.forEach(function (friend) {
       if (friend.user_id === rider.user_id) {

--- a/client/lib/fetchHelpers.js
+++ b/client/lib/fetchHelpers.js
@@ -4,11 +4,11 @@ export const headers = {
 };
 
 export function json(response) {
-  return response.json()
+  return response.json();
 }
 
 export function checkStatus(response) {
-  if (response.status >= 200 && response.status < 300) {
+  if (response.status === 418 || (response.status >= 200 && response.status < 300)) {
     return response;
   } else {
     var error = new Error(response.statusText);

--- a/client/reducers/cancelRide.js
+++ b/client/reducers/cancelRide.js
@@ -20,8 +20,6 @@ function cancelRide(state, action) {
     match: null,
   };
 
-  console.log('cancel ride next state:', state.merge(updates).toJS());
-
   return state.merge(updates);
 }
 

--- a/client/reducers/fetchRide.js
+++ b/client/reducers/fetchRide.js
@@ -1,6 +1,6 @@
 export function handleRideFetch(state, action) {
 
-  console.log('fetchRide state:', state.toJS());
+  // console.log('fetchRide state:', state.toJS());
   switch (action.type) {
     case 'REQUEST_RIDE':
       return requestRide(state, action);

--- a/client/reducers/riders.js
+++ b/client/reducers/riders.js
@@ -1,8 +1,9 @@
 import { List, fromJS } from 'immutable';
+import { uniqBy, prop } from 'ramda';
 
 export function handleRiders(state = List(), action) {
 
-  console.log('reducing riders:', state.toJS());
+  // console.log('reducing riders:', state.toJS());
   switch (action.type) {
     case 'ADD_RIDER':
       return addRider(state, action);
@@ -14,20 +15,20 @@ export function handleRiders(state = List(), action) {
 }
 
 // adds a rider or array of riders to the state riders list.
-function addRider(state, action) {
-  let nextState = null;
+function addRider(_state, { entry }) {
+  let state = _state.toJS();
 
-  if (Array.isArray(action.entry))
-    nextState = state.push(...action.entry);
-  else
-    nextState = state.push(action.entry);
+  if (!Array.isArray(entry)) entry = [entry];
 
-  return nextState;
+  state.push(...entry);
+  let nextState = uniqBy(prop('user_id'), state);
+
+  return fromJS(nextState);
 };
 
-function removeRider(state, action) {
+function removeRider(state, { entry }) {
   let oldRiders = state.toJS();
-  let newRiders = oldRiders.filter((rider) => rider.user_id !== action.entry);
+  let newRiders = oldRiders.filter((rider) => rider.user_id !== entry);
 
   return fromJS(newRiders);
 }

--- a/client/reducers/userInfo.js
+++ b/client/reducers/userInfo.js
@@ -67,12 +67,16 @@ function requestUserInfoError(state, { entry }) {
 function receiveFriendInfo(state, { entry }) {
   let old = state.toJS().friends;
   let user = JSON.parse(localStorage.getItem('user'));
+
+  console.log('received a new user:', entry);
   let newFriend = {
     avatar: entry.avatar,
     name: entry.name,
     user_id: entry.user_id,
+    address: entry.address,
   };
   old.push(newFriend);
+  console.log('new friends list:', old);
   user.friends.push(newFriend);
 
   localStorage.setItem('user', JSON.stringify(user));

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -44,13 +44,13 @@ knex.schema.createTableIfNotExists('users', function (table) {
 })
 .createTableIfNotExists('riders', function (table) {
   table.increments('rider_id').primary().notNullable();
-  table.integer('foreign_rider').references('user_id').inTable('users').notNullable();
+  table.integer('foreign_rider').references('user_id').inTable('users').notNullable().unique();
   table.string('location').notNullable();
   table.timestamp('created_at');
 })
 .createTableIfNotExists('drivers', function (table) {
   table.increments('driver_id').primary();
-  table.integer('foreign_driver').references('user_id').inTable('users').notNullable();
+  table.integer('foreign_driver').references('user_id').inTable('users').notNullable().unique();
   table.string('location').notNullable();
   table.timestamp('created_at');
 })

--- a/server/apis/user-api.js
+++ b/server/apis/user-api.js
@@ -51,6 +51,7 @@ UserAPI.post('/friends', function (request, response) {
 
   Friends.findAndAddFriend(user_id, searchString)
     .then((friend) => {
+      // Just start the async call, we don't have to continue the chain.
       User.findUserById(user_id)
         .then((requestingUser) => io.to(friend.user_id).emit('new_friend', requestingUser));
 

--- a/server/models/rides.js
+++ b/server/models/rides.js
@@ -65,6 +65,7 @@ Ride.getRiderById = function (userId) {
 // Create a rider
 Ride.createRider = function (attrs) {
   return db('riders').insert(attrs, ['rider_id', 'foreign_rider', 'location'])
+    .then(first)
     .catch(reportError('error creating rider in db'));
 };
 

--- a/server/server-helpers.js
+++ b/server/server-helpers.js
@@ -9,7 +9,7 @@ global.reportError = R.curry(function (description, error) {
   if (error instanceof Error) throw error;
 });
 
-global.sendStatus = R.curry(function (response, status) {
+global.sendStatus = R.curry(function (response, status, _) {
   response.sendStatus(status);
 });
 


### PR DESCRIPTION
* BUGFIX: Riders and Drivers are no longer duplicated in their tables if they're already there. 

* BUGFIX: sendStatus server helper would always respond

* BUGFIX: when friends were added via socket commands, they were being treated as riders and so did not input an address. This caused problems routing only some friends.